### PR TITLE
Add Salesforce sheet Jspreadsheet demo

### DIFF
--- a/app/salesforce-sheet/index.html
+++ b/app/salesforce-sheet/index.html
@@ -1,0 +1,266 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Salesforce Sheet | Jspreadsheet CE</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/jsuites@4.17.3/dist/jsuites.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/jspreadsheet-ce@4.12.4/dist/jspreadsheet.min.css"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      body {
+        margin: 0;
+        font-family: "Inter", system-ui, -apple-system, sans-serif;
+        background: radial-gradient(circle at 20% 20%, #eef2ff, transparent 35%),
+          radial-gradient(circle at 80% 0%, #e0f7ff, transparent 30%),
+          #f7fafc;
+        color: #0f172a;
+      }
+      header {
+        padding: 48px 24px 16px;
+        max-width: 1100px;
+        margin: 0 auto;
+      }
+      header h1 {
+        margin: 0;
+        font-size: clamp(28px, 4vw, 40px);
+      }
+      header p {
+        margin: 12px 0 0;
+        color: #334155;
+        max-width: 720px;
+        line-height: 1.6;
+      }
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 0 24px 48px;
+      }
+      .panel {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        box-shadow: 0 20px 45px -20px rgba(15, 23, 42, 0.25);
+        border-radius: 18px;
+        padding: 20px;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+        margin-bottom: 14px;
+      }
+      .actions button,
+      .actions a {
+        border: none;
+        background: #0ea5e9;
+        color: white;
+        font-weight: 600;
+        padding: 10px 14px;
+        border-radius: 12px;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        text-decoration: none;
+        transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+        box-shadow: 0 10px 20px -12px rgba(14, 165, 233, 0.8);
+      }
+      .actions button:hover,
+      .actions a:hover {
+        transform: translateY(-1px);
+        background: #0284c7;
+      }
+      .actions .secondary {
+        background: #e2e8f0;
+        color: #0f172a;
+        box-shadow: none;
+      }
+      .actions .secondary:hover {
+        background: #cbd5e1;
+      }
+      #spreadsheet {
+        border-radius: 14px;
+        overflow: hidden;
+        border: 1px solid #e2e8f0;
+      }
+      .tips {
+        margin-top: 18px;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 12px;
+      }
+      .tip {
+        background: #0f172a;
+        color: white;
+        border-radius: 14px;
+        padding: 14px 16px;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05),
+          0 12px 25px -18px rgba(15, 23, 42, 0.6);
+      }
+      .tip h3 {
+        margin: 0 0 6px;
+        font-size: 15px;
+      }
+      .tip p {
+        margin: 0;
+        color: rgba(255, 255, 255, 0.85);
+        line-height: 1.5;
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: #dbeafe;
+        color: #1e3a8a;
+        padding: 6px 10px;
+        border-radius: 9999px;
+        font-weight: 600;
+        font-size: 14px;
+        margin-top: 18px;
+      }
+      footer {
+        text-align: center;
+        color: #475569;
+        font-size: 14px;
+        padding: 20px 0 0;
+      }
+      @media (max-width: 640px) {
+        header,
+        main {
+          padding-left: 18px;
+          padding-right: 18px;
+        }
+        .actions {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+        .actions button,
+        .actions a {
+          width: 100%;
+          justify-content: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="badge">
+        <span>📊 Salesforce Sheet</span>
+        <span>Powered by Jspreadsheet CE</span>
+      </div>
+      <h1>Interactive pipeline grid</h1>
+      <p>
+        Explore a spreadsheet-like view of Salesforce opportunities with live formulas, dropdowns, and date pickers.
+        Update probabilities, adjust close dates, or insert new rows — weighted pipeline totals update instantly thanks to
+        Jspreadsheet CE's Excel-like engine.
+      </p>
+    </header>
+
+    <main>
+      <div class="panel">
+        <div class="actions">
+          <button id="add-row" type="button">➕ Add opportunity</button>
+          <button id="download-csv" type="button" class="secondary">⬇️ Export CSV</button>
+          <a class="secondary" href="https://jspreadsheet.com/v4/" target="_blank" rel="noreferrer">📘 Jspreadsheet docs</a>
+        </div>
+        <div id="spreadsheet"></div>
+        <div class="tips">
+          <div class="tip">
+            <h3>Formulas you can extend</h3>
+            <p>Weighted Amount uses <code>=C#*D#</code>. Copy or fill the column to apply the calculation to new deals.</p>
+          </div>
+          <div class="tip">
+            <h3>Excel-friendly controls</h3>
+            <p>Use the stage dropdown, numeric masks, and calendar picker to keep data consistent while editing inline.</p>
+          </div>
+          <div class="tip">
+            <h3>Summaries</h3>
+            <p>The bottom row tracks a rolling weighted pipeline total with <code>=SUM(F2:F6)</code>. Adjust it to fit your slice.</p>
+          </div>
+        </div>
+      </div>
+      <footer>Works entirely in the browser — no Salesforce org required.</footer>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/jsuites@4.17.3/dist/jsuites.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jspreadsheet-ce@4.12.4/dist/jspreadsheet.min.js"></script>
+    <script>
+      const sheetElement = document.getElementById('spreadsheet');
+      const defaultData = [
+        ['Acme Data Cloud Expansion', 'Proposal/Price Quote', 120000, 0.65, '2024-08-30', '=C2*D2'],
+        ['Buttercup Retail Rollout', 'Qualification', 85000, 0.45, '2024-09-12', '=C3*D3'],
+        ['Northern Analytics Suite', 'Negotiation/Review', 142500, 0.55, '2024-07-22', '=C4*D4'],
+        ['Trailhead Workforce', 'Prospecting', 62000, 0.3, '2024-10-05', '=C5*D5'],
+        ['Omni-Channel Service Desk', 'Proposal/Price Quote', 98000, 0.5, '2024-08-14', '=C6*D6'],
+        ['Pipeline Total', '', '', '', 'Weighted Sum', '=SUM(F2:F6)']
+      ];
+
+      const stageOptions = [
+        'Prospecting',
+        'Qualification',
+        'Needs Analysis',
+        'Value Proposition',
+        'Proposal/Price Quote',
+        'Negotiation/Review',
+        'Closed Won',
+        'Closed Lost'
+      ];
+
+      const spreadsheet = jspreadsheet(sheetElement, {
+        data: defaultData,
+        minDimensions: [6, defaultData.length],
+        defaultColWidth: 170,
+        rowResize: true,
+        columnDrag: true,
+        allowInsertRow: true,
+        allowManualInsertRow: true,
+        tableOverflow: true,
+        tableWidth: '100%',
+        columns: [
+          { type: 'text', title: 'Opportunity Name', width: 230 },
+          { type: 'dropdown', title: 'Stage', width: 180, source: stageOptions },
+          { type: 'numeric', title: 'Amount', mask: '$ #,##0', decimal: '.', width: 120 },
+          { type: 'numeric', title: 'Probability', mask: '0%', decimal: '.', width: 110 },
+          { type: 'calendar', title: 'Close Date', width: 130, options: { format: 'YYYY-MM-DD' } },
+          { type: 'numeric', title: 'Weighted Amount', mask: '$ #,##0', decimal: '.', width: 140, readOnly: false }
+        ],
+        updateTable(instance, cell, col, row) {
+          const isSummaryRow = row === instance.getData().length - 1 || instance.getValueFromCoords(0, row) === 'Pipeline Total';
+          if (isSummaryRow) {
+            cell.style.fontWeight = '700';
+            cell.style.backgroundColor = '#f1f5f9';
+          }
+        }
+      });
+
+      const updateSummaryFormula = () => {
+        const summaryRowNumber = spreadsheet.getData().length;
+        spreadsheet.setValue(`F${summaryRowNumber}`, `=SUM(F2:F${summaryRowNumber - 1})`);
+      };
+
+      updateSummaryFormula();
+
+      document.getElementById('add-row').addEventListener('click', () => {
+        const summaryRowIndex = spreadsheet.getData().length - 1;
+        spreadsheet.insertRow(1, summaryRowIndex);
+
+        const newRowNumber = summaryRowIndex + 1; // 1-based cell address after insertion
+        spreadsheet.setValue(`F${newRowNumber}`, `=C${newRowNumber}*D${newRowNumber}`);
+        updateSummaryFormula();
+      });
+
+      document.getElementById('download-csv').addEventListener('click', () => {
+        spreadsheet.download(true, null, 'salesforce-pipeline.csv');
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a new /app/salesforce-sheet page featuring a Salesforce-inspired pipeline grid
- wire up Jspreadsheet CE with dropdowns, calendar inputs, and weighted amount formulas
- provide quick actions for inserting rows, exporting CSV, and linking to documentation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935863d3044832ea33bc5ee934fd8fd)