### PR TITLE
Revamp landing for beautiful apps and stabilize Salesforce sheet

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,73 +14,68 @@
     referrerpolicy="no-referrer"
   />
 </head>
-<body class="min-h-screen bg-gradient-to-b from-blue-50 via-white to-slate-50 text-slate-900">
-  <header class="bg-white/80 backdrop-blur border-b border-slate-200 sticky top-0 z-20">
-    <div class="max-w-6xl mx-auto px-4 py-4 space-y-3 md:space-y-0">
-      <div class="flex items-center justify-between gap-4">
-        <a href="{{ '/' | relative_url }}" class="flex items-center gap-3">
-          <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-blue-600 text-white font-bold shadow-lg">A</span>
-          <div>
-            <p class="text-sm font-semibold text-blue-600">Andi &amp; Anna</p>
-            <p class="text-base font-bold text-slate-900">Games Room</p>
-          </div>
-        </a>
-        <div class="flex items-center gap-3">
-          <nav class="hidden md:block" aria-label="Primary">
-            <ul class="flex items-center gap-6 text-sm font-semibold text-slate-700">
-              <li><a class="hover:text-blue-600 transition-colors" href="{{ '/' | relative_url }}">Home</a></li>
-              <li><a class="hover:text-blue-600 transition-colors" href="{{ '/#apps' | relative_url }}">Apps</a></li>
-              <li><a class="hover:text-blue-600 transition-colors" href="{{ '/feature/salesforce-sheet/' | relative_url }}">Salesforce Sheet</a></li>
-              <li><a class="hover:text-blue-600 transition-colors" href="{{ '/#games' | relative_url }}">Games</a></li>
-              <li><a class="hover:text-blue-600 transition-colors" href="{{ '/login/' | relative_url }}">Login</a></li>
-            </ul>
-          </nav>
-          <button
-            type="button"
-            id="mobile-menu-toggle"
-            class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm md:hidden"
-            aria-expanded="false"
-            aria-controls="mobile-nav"
-          >
-            <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-            Menu
-          </button>
-          <a
-            class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-blue-500 via-blue-600 to-indigo-700 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-blue-200 hover:shadow-xl"
-            href="{{ '/login/' | relative_url }}"
-          >
-            <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-              <path d="M3 4a2 2 0 0 1 2-2h6a1 1 0 1 1 0 2H5v12h6a1 1 0 1 1 0 2H5a2 2 0 0 1-2-2V4Zm10.293 3.293a1 1 0 0 1 1.414 0l3 3a1 1 0 0 1 0 1.414l-3 3A1 1 0 0 1 13.293 14L15.586 12H9a1 1 0 1 1 0-2h6.586l-2.293-2.293a1 1 0 0 1 0-1.414Z" />
-            </svg>
-            Login portal
-          </a>
+<body class="min-h-screen bg-gradient-to-b from-slate-900 via-slate-800 to-slate-900 text-slate-50">
+  <div class="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(59,130,246,0.15),transparent_25%),radial-gradient(circle_at_80%_0%,rgba(16,185,129,0.12),transparent_20%),radial-gradient(circle_at_50%_80%,rgba(236,72,153,0.1),transparent_25%)] pointer-events-none"></div>
+
+  <header class="sticky top-0 z-20 border-b border-white/10 bg-slate-900/80 backdrop-blur">
+    <div class="relative mx-auto flex max-w-6xl flex-col gap-3 px-4 py-4 md:flex-row md:items-center md:justify-between">
+      <a href="{{ '/' | relative_url }}" class="flex items-center gap-3 text-left">
+        <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-emerald-500 text-lg font-black shadow-lg shadow-blue-500/30">BA</span>
+        <div>
+          <p class="text-xs uppercase tracking-[0.25em] text-blue-200">Beautiful Apps</p>
+          <p class="text-base font-semibold text-white">Experiences that feel designed</p>
         </div>
+      </a>
+      <div class="flex items-center gap-3">
+        <nav class="hidden md:block" aria-label="Primary">
+          <ul class="flex items-center gap-6 text-sm font-semibold text-slate-100">
+            <li><a class="hover:text-emerald-300 transition-colors" href="{{ '/#apps' | relative_url }}">Apps</a></li>
+            <li><a class="hover:text-emerald-300 transition-colors" href="{{ '/feature/salesforce-sheet/' | relative_url }}">Salesforce Sheet</a></li>
+            <li><a class="hover:text-emerald-300 transition-colors" href="{{ '/#games' | relative_url }}">Playground</a></li>
+            <li><a class="hover:text-emerald-300 transition-colors" href="{{ '/login/' | relative_url }}">Portal</a></li>
+          </ul>
+        </nav>
+        <button
+          type="button"
+          id="mobile-menu-toggle"
+          class="inline-flex items-center justify-center gap-2 rounded-xl border border-white/15 bg-white/5 px-3 py-2 text-sm font-semibold text-white shadow-sm md:hidden"
+          aria-expanded="false"
+          aria-controls="mobile-nav"
+        >
+          <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          Menu
+        </button>
+        <a
+          class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-emerald-400 via-blue-500 to-indigo-500 px-4 py-2 text-sm font-semibold text-slate-900 shadow-lg shadow-blue-500/30"
+          href="{{ '/feature/salesforce-sheet/' | relative_url }}"
+        >
+          ✨ Launch flagship app
+        </a>
       </div>
-      <nav id="mobile-nav" class="md:hidden hidden border-t border-slate-200 pt-3" aria-label="Primary mobile">
-        <ul class="flex flex-col gap-2 text-sm font-semibold text-slate-700">
-          <li><a class="flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-blue-50 hover:text-blue-600" href="{{ '/' | relative_url }}">Home</a></li>
-          <li><a class="flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-blue-50 hover:text-blue-600" href="{{ '/#apps' | relative_url }}">Apps</a></li>
-          <li><a class="flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-blue-50 hover:text-blue-600" href="{{ '/feature/salesforce-sheet/' | relative_url }}">Salesforce Sheet</a></li>
-          <li><a class="flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-blue-50 hover:text-blue-600" href="{{ '/#games' | relative_url }}">Games</a></li>
-          <li><a class="flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-blue-50 hover:text-blue-600" href="{{ '/login/' | relative_url }}">Login</a></li>
-        </ul>
-      </nav>
     </div>
+    <nav id="mobile-nav" class="relative hidden border-t border-white/10 bg-slate-900/90 px-4 py-3 md:hidden" aria-label="Primary mobile">
+      <ul class="flex flex-col gap-2 text-sm font-semibold text-white/90">
+        <li><a class="flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-white/5" href="{{ '/#apps' | relative_url }}">Apps</a></li>
+        <li><a class="flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-white/5" href="{{ '/feature/salesforce-sheet/' | relative_url }}">Salesforce Sheet</a></li>
+        <li><a class="flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-white/5" href="{{ '/#games' | relative_url }}">Playground</a></li>
+        <li><a class="flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-white/5" href="{{ '/login/' | relative_url }}">Portal</a></li>
+      </ul>
+    </nav>
   </header>
 
-  <main class="max-w-6xl mx-auto px-4 py-10">{{ content }}</main>
+  <main class="relative z-10 mx-auto max-w-6xl px-4 py-10">{{ content }}</main>
 
-  <footer class="max-w-6xl mx-auto px-4 pb-10 text-sm text-slate-500">
-    <div class="flex flex-wrap items-center justify-between gap-4 rounded-2xl bg-white/70 p-6 shadow-sm ring-1 ring-slate-200">
+  <footer class="relative z-10 mx-auto max-w-6xl px-4 pb-12 text-sm text-white/70">
+    <div class="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-indigo-900/30">
       <div>
-        <p class="font-semibold text-slate-800">Built with love &amp; Flowbite</p>
-        <p>Enjoy a curated set of games and utilities all in one place.</p>
+        <p class="font-semibold text-white">Built for teams who care about beauty and speed.</p>
+        <p>Every app ships with gradients, glassmorphism, and responsive polish.</p>
       </div>
-      <div class="flex items-center gap-3 text-slate-700">
-        <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-blue-700">🎮</span>
-        <span class="font-semibold">Play, learn, and explore.</span>
+      <div class="flex items-center gap-3 text-white">
+        <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-emerald-400 text-lg">🌈</span>
+        <span class="font-semibold">Beautiful apps. Delightful details.</span>
       </div>
     </div>
   </footer>

--- a/feature/salesforce-sheet/index.html
+++ b/feature/salesforce-sheet/index.html
@@ -4,7 +4,7 @@ title: "Salesforce Sheet | Pipeline Console"
 description: "Inline-editable Salesforce-style sheet for tracking opportunities, stages, and exports."
 ---
 <section class="space-y-8">
-  <div class="flex flex-wrap items-center justify-between gap-4">
+  <div class="flex flex-wrap items-center justify-between gap-4" id="about">
     <div>
       <p class="text-sm font-semibold text-blue-600">Salesforce utility</p>
       <h1 class="text-3xl font-bold text-slate-900">Salesforce Sheet</h1>
@@ -56,11 +56,11 @@ description: "Inline-editable Salesforce-style sheet for tracking opportunities,
       </div>
       <link
         rel="stylesheet"
-        href="https://cdn.jsdelivr.net/npm/jspreadsheet-ce@5.4.0/dist/jspreadsheet.min.css"
+        href="https://cdn.jsdelivr.net/npm/jspreadsheet-ce@5.4.4/dist/jspreadsheet.min.css"
       />
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsuites@4.17.2/dist/jsuites.min.css" />
-      <script src="https://cdn.jsdelivr.net/npm/jspreadsheet-ce@5.4.0/dist/jspreadsheet.min.js"></script>
-      <script src="https://cdn.jsdelivr.net/npm/jsuites@4.17.2/dist/jsuites.min.js"></script>
+      <script defer src="https://cdn.jsdelivr.net/npm/jspreadsheet-ce@5.4.4/dist/jspreadsheet.min.js"></script>
+      <script defer src="https://cdn.jsdelivr.net/npm/jsuites@4.17.2/dist/jsuites.min.js"></script>
     </div>
 
     <div class="space-y-4">
@@ -113,11 +113,13 @@ description: "Inline-editable Salesforce-style sheet for tracking opportunities,
 
 <script>
   (() => {
+    const safeId = () => (window.crypto?.randomUUID ? window.crypto.randomUUID() : `row-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+
     const stageOptions = ['Prospecting', 'Discovery', 'Proposal', 'Negotiation', 'Closed Won', 'Closed Lost'];
 
     const data = [
       {
-        id: crypto.randomUUID(),
+        id: safeId(),
         owner: 'Andi Adams',
         account: 'Northern Trails',
         opportunity: 'Service Cloud rollout',
@@ -127,7 +129,7 @@ description: "Inline-editable Salesforce-style sheet for tracking opportunities,
         notes: 'Mapping support channels'
       },
       {
-        id: crypto.randomUUID(),
+        id: safeId(),
         owner: 'Anna Lee',
         account: 'S-Force Retail',
         opportunity: 'Commerce + OMS expansion',
@@ -137,7 +139,7 @@ description: "Inline-editable Salesforce-style sheet for tracking opportunities,
         notes: 'Needs ROI deck and sandbox demo'
       },
       {
-        id: crypto.randomUUID(),
+        id: safeId(),
         owner: 'Kai Brown',
         account: 'Blue Horizon',
         opportunity: 'Analytics Cloud pilot',
@@ -176,14 +178,12 @@ description: "Inline-editable Salesforce-style sheet for tracking opportunities,
       });
     };
 
-    setStageOptions(stageFilter, true);
-    setStageOptions(addForm.elements.namedItem('stage'));
-
-    let filteredRows = data;
-
     const formatCurrency = (value) => {
       return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(Number(value || 0));
     };
+
+    const mapToGridData = (rows) =>
+      rows.map((row) => [row.owner, row.account, row.opportunity, row.amount, row.stage, row.closeDate, row.notes]);
 
     const renderSummary = () => {
       const totals = data.reduce(
@@ -216,84 +216,124 @@ description: "Inline-editable Salesforce-style sheet for tracking opportunities,
       });
     };
 
-    const mapToGridData = (rows) =>
-      rows.map((row) => [row.owner, row.account, row.opportunity, row.amount, row.stage, row.closeDate, row.notes]);
+    const stageSelect = addForm.elements.namedItem('stage');
+    setStageOptions(stageFilter, true);
+    setStageOptions(stageSelect);
 
-    const sheet = jspreadsheet(sheetContainer, {
-      data: mapToGridData(data),
-      columns: [
-        { title: 'Owner', width: 140 },
-        { title: 'Account', width: 160 },
-        { title: 'Opportunity', width: 200 },
-        {
-          title: 'Amount ($)',
-          type: 'numeric',
-          mask: '$ #,##0',
-          decimal: '.',
-          thousands: ',',
-          width: 120
-        },
-        { title: 'Stage', type: 'dropdown', source: stageOptions, width: 150 },
-        { title: 'Close Date', type: 'calendar', options: { format: 'YYYY-MM-DD' }, width: 140 },
-        { title: 'Notes', type: 'text', wordWrap: true, width: 260 }
-      ],
-      allowInsertColumn: false,
-      allowDeleteColumn: false,
-      allowDeleteRow: true,
-      tableOverflow: true,
-      tableHeight: '420px',
-      contextMenu: (obj, x, y) => {
-        const items = [];
-
-        if (y !== null && filteredRows[y]) {
-          items.push({
-            title: 'Delete row',
-            onclick: () => {
-              const index = data.indexOf(filteredRows[y]);
-              if (index >= 0) {
-                data.splice(index, 1);
-                refreshSheet();
-                renderSummary();
-              }
-            }
-          });
-        }
-
-        return items;
-      },
-      onafterchanges: (_, records) => {
-        let requiresFilterRefresh = false;
-        records.forEach(({ x, y, value }) => {
-          const row = filteredRows[y];
-          if (!row) return;
-          const key = columnKeys[x];
-          row[key] = key === 'amount' ? Number(value) || 0 : value;
-          if (key === 'stage') {
-            requiresFilterRefresh = true;
-          }
-        });
-        if (requiresFilterRefresh && stageFilter.value) {
-          refreshSheet();
-        }
-        renderSummary();
-      }
-    });
+    let filteredRows = data;
+    let sheet;
 
     const refreshSheet = () => {
+      if (!sheet) return;
       const filter = stageFilter.value;
       filteredRows = filter ? data.filter((row) => row.stage === filter) : data;
       sheet.setData(mapToGridData(filteredRows));
     };
 
+    const handleLoadFailure = (message) => {
+      sheetContainer.innerHTML = `<div class="p-4 text-sm text-rose-700 bg-rose-50 border border-rose-200 rounded-lg">${message}</div>`;
+    };
+
+    const waitForSpreadsheet = () =>
+      new Promise((resolve, reject) => {
+        let attempts = 0;
+        const maxAttempts = 80;
+
+        const poll = () => {
+          const lib = window.jspreadsheet?.default || window.jspreadsheet || window.jSpreadsheet || window.jexcel;
+          if (lib) {
+            resolve(lib);
+            return;
+          }
+
+          if (attempts++ > maxAttempts) {
+            reject(new Error('jspreadsheet failed to load'));
+            return;
+          }
+
+          requestAnimationFrame(poll);
+        };
+
+        poll();
+      });
+
+    waitForSpreadsheet()
+      .then((spreadsheetLib) => {
+        sheet = spreadsheetLib(sheetContainer, {
+          data: mapToGridData(data),
+          columns: [
+            { title: 'Owner', width: 140 },
+            { title: 'Account', width: 160 },
+            { title: 'Opportunity', width: 200 },
+            {
+              title: 'Amount ($)',
+              type: 'numeric',
+              mask: '$ #,##0',
+              decimal: '.',
+              thousands: ',',
+              width: 120
+            },
+            { title: 'Stage', type: 'dropdown', source: stageOptions, width: 150 },
+            { title: 'Close Date', type: 'calendar', options: { format: 'YYYY-MM-DD' }, width: 140 },
+            { title: 'Notes', type: 'text', wordWrap: true, width: 260 }
+          ],
+          allowInsertColumn: false,
+          allowDeleteColumn: false,
+          allowDeleteRow: true,
+          tableOverflow: true,
+          tableHeight: '420px',
+          contextMenu: (obj, x, y) => {
+            const items = [];
+
+            if (y !== null && filteredRows[y]) {
+              items.push({
+                title: 'Delete row',
+                onclick: () => {
+                  const index = data.indexOf(filteredRows[y]);
+                  if (index >= 0) {
+                    data.splice(index, 1);
+                    refreshSheet();
+                    renderSummary();
+                  }
+                }
+              });
+            }
+
+            return items;
+          },
+          onafterchanges: (_, records) => {
+            let requiresFilterRefresh = false;
+            records.forEach(({ x, y, value }) => {
+              const row = filteredRows[y];
+              if (!row) return;
+              const key = columnKeys[x];
+              row[key] = key === 'amount' ? Number(value) || 0 : value;
+              if (key === 'stage') {
+                requiresFilterRefresh = true;
+              }
+            });
+            if (requiresFilterRefresh && stageFilter.value) {
+              refreshSheet();
+            }
+            renderSummary();
+          }
+        });
+
+        renderSummary();
+      })
+      .catch((err) => {
+        console.error(err);
+        handleLoadFailure('The spreadsheet engine did not load. Please refresh to retry.');
+      });
+
     addForm.addEventListener('submit', (event) => {
       event.preventDefault();
       const formData = new FormData(addForm);
       const newRow = Object.fromEntries(formData.entries());
-      newRow.id = crypto.randomUUID();
+      newRow.id = safeId();
       newRow.amount = Number(newRow.amount) || 0;
       data.unshift(newRow);
       addForm.reset();
-      const stageSelect = addForm.elements.namedItem('stage');
       if (stageSelect) stageSelect.value = stageOptions[0];
       refreshSheet();
       renderSummary();

--- a/index.html
+++ b/index.html
@@ -1,78 +1,84 @@
 ---
 layout: default
-title: "Andi & Anna Games Room"
+title: "Beautiful Apps Studio"
 ---
-<section class="grid gap-10 lg:grid-cols-2 items-center mb-12">
-  <div class="space-y-4">
-    <div class="inline-flex items-center gap-2 rounded-full bg-blue-100 text-blue-700 px-4 py-2 text-sm font-semibold shadow-sm">
-      <span class="h-2.5 w-2.5 rounded-full bg-blue-500"></span>
-      Flowbite-powered fun hub
+<section class="grid gap-10 lg:grid-cols-2 items-center mb-14">
+  <div class="space-y-6">
+    <div class="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-200 ring-1 ring-emerald-300/30">
+      Crafted digital tools • Smooth gradients • Fast interactions
     </div>
-    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight text-slate-900">🎮 Andi &amp; Anna Games Room</h1>
-    <p class="text-lg text-slate-600">
-      Pick a game and start playing instantly. Each experience lives in its own
-      <code class="text-sm bg-slate-900/90 text-white px-2 py-1 rounded">/games/&lt;name&gt;/index.html</code> folder.
+    <h1 class="text-4xl sm:text-5xl font-black leading-tight text-white">
+      Beautiful apps that feel boutique.
+    </h1>
+    <p class="text-lg text-white/80 max-w-2xl">
+      Launch utility dashboards, worksheets, and playful experiments from a single studio. Each app ships with glassy cards, modern typography, and tiny touches that make work feel like art.
     </p>
     <div class="flex flex-wrap items-center gap-3 pt-2">
       <a
-        class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-blue-500 via-blue-600 to-indigo-700 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-blue-200 hover:shadow-xl"
+        class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-emerald-400 via-blue-500 to-indigo-500 px-5 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-blue-500/30"
+        href="{{ '/feature/salesforce-sheet/' | relative_url }}"
+      >
+        🚀 Open Salesforce Sheet
+      </a>
+      <a
+        class="inline-flex items-center gap-2 rounded-xl border border-white/15 bg-white/5 px-5 py-3 text-sm font-semibold text-white hover:border-emerald-200/60"
         href="{{ '/login/' | relative_url }}"
       >
-        🔐 Go to login portal
+        🔐 Team portal
       </a>
       <div class="flex -space-x-2 overflow-hidden">
-        <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-lg">🎲</span>
-        <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-lg">🧮</span>
-        <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-indigo-100 text-lg">🧠</span>
+        <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-lg">🎛️</span>
+        <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-lg">📊</span>
+        <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-lg">🎨</span>
       </div>
     </div>
   </div>
   <div class="grid gap-4 sm:grid-cols-2">
-    <div class="rounded-2xl bg-white/70 shadow-lg ring-1 ring-slate-200 p-5">
-      <p class="text-sm font-semibold text-blue-600">Library</p>
-      <p class="text-2xl font-bold text-slate-900">{{ site.data.games | size }} games</p>
-      <p class="text-slate-600 mt-2">Math drills, puzzles, and 3D adventures ready to launch.</p>
+    <div class="rounded-2xl bg-white/5 border border-white/10 p-5 shadow-lg shadow-indigo-900/30">
+      <p class="text-sm font-semibold text-emerald-200">App collection</p>
+      <p class="text-3xl font-bold text-white">{{ site.data.apps | size }} flagship tool</p>
+      <p class="text-white/70 mt-2">Hand-built experiences that keep teams focused.</p>
     </div>
     <div class="rounded-2xl bg-gradient-to-br from-indigo-500 via-blue-600 to-cyan-500 shadow-xl p-5 text-white">
-      <p class="text-sm font-semibold">Play anywhere</p>
-      <p class="text-2xl font-bold">Web-first experiences</p>
-      <p class="text-white/90 mt-2">Responsive layouts and Flowbite components keep everything crisp.</p>
+      <p class="text-sm font-semibold">Design-first</p>
+      <p class="text-2xl font-bold">Glassmorphism UI</p>
+      <p class="text-white/90 mt-2">Soft borders, layered gradients, and subtle blurs keep every screen cinematic.</p>
     </div>
-    <div class="rounded-2xl bg-white/70 shadow-lg ring-1 ring-slate-200 p-5">
-      <p class="text-sm font-semibold text-emerald-600">Easy setup</p>
-      <p class="text-slate-700">Add a folder in <code class="text-xs bg-slate-900/90 text-white px-2 py-1 rounded">/games/</code> and list it in <code class="text-xs bg-slate-900/90 text-white px-2 py-1 rounded">_data/games.yml</code>.</p>
+    <div class="rounded-2xl bg-white/5 border border-white/10 p-5 shadow-lg shadow-indigo-900/30">
+      <p class="text-sm font-semibold text-amber-200">Performance</p>
+      <p class="text-white/80">CDN-backed assets, lightweight pages, and quick launches from any device.</p>
     </div>
-    <div class="rounded-2xl bg-white/70 shadow-lg ring-1 ring-slate-200 p-5">
-      <p class="text-sm font-semibold text-purple-600">Community vibes</p>
-      <p class="text-slate-700">Bright badges, smooth shadows, and inviting gradients welcome everyone.</p>
+    <div class="rounded-2xl bg-white/5 border border-white/10 p-5 shadow-lg shadow-indigo-900/30">
+      <p class="text-sm font-semibold text-purple-200">Playground</p>
+      <p class="text-white/80">A curated shelf of 3D demos and learning games to spark joy.</p>
     </div>
   </div>
 </section>
 
-<section id="apps" class="mt-12 space-y-4">
+<section class="space-y-6" id="apps">
   <div class="flex items-center justify-between gap-4">
     <div>
-      <p class="text-sm font-semibold text-blue-600">App center</p>
-      <h2 class="text-2xl font-bold text-slate-900">Launch mini-apps</h2>
-      <p class="text-slate-600">Handy utilities that live alongside the games.</p>
+      <p class="text-sm font-semibold text-emerald-200">App studio</p>
+      <h2 class="text-3xl font-bold text-white">Launch beautiful apps</h2>
+      <p class="text-white/70 max-w-2xl">Each card opens a crafted experience with delightful UI and pragmatic workflows.</p>
     </div>
-    <span class="inline-flex items-center gap-2 rounded-full bg-indigo-100 text-indigo-700 px-3 py-1 text-sm font-semibold ring-1 ring-indigo-200">Featured</span>
+    <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-xs font-semibold text-white ring-1 ring-white/20">Live &amp; ready</span>
   </div>
   <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
     {% for app in site.data.apps %}
     <a
       href="{{ app.path | relative_url }}"
-      class="group block h-full overflow-hidden rounded-2xl bg-white shadow-md ring-1 ring-slate-200 transition hover:-translate-y-1 hover:shadow-xl"
+      class="group block h-full overflow-hidden rounded-2xl border border-white/10 bg-white/5 shadow-lg shadow-indigo-900/30 ring-1 ring-transparent transition hover:-translate-y-1 hover:ring-emerald-300/50"
     >
-      <div class="bg-gradient-to-r from-indigo-600 via-blue-600 to-cyan-500 px-5 py-4 text-white">
-        <p class="text-xs font-semibold uppercase tracking-wide text-indigo-100">{{ app.category | default: 'App' }}</p>
+      <div class="bg-gradient-to-r from-emerald-400 via-blue-500 to-indigo-500 px-5 py-4 text-slate-900">
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-900/80">{{ app.category | default: 'App' }}</p>
         <h3 class="text-lg font-bold">{{ app.title }}</h3>
       </div>
       <div class="p-5 space-y-3">
-        <p class="text-sm text-slate-600">{{ app.description | escape }}</p>
-        <div class="flex items-center justify-between text-sm font-semibold text-indigo-700">
+        <p class="text-sm text-white/80">{{ app.description | escape }}</p>
+        <div class="flex items-center justify-between text-sm font-semibold text-emerald-200">
           <span class="inline-flex items-center gap-2">Open app</span>
-          <span class="inline-flex items-center gap-2 rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-indigo-200">{{ app.badge | default: 'Live' }}</span>
+          <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-white ring-1 ring-white/10">{{ app.badge | default: 'Live' }}</span>
         </div>
       </div>
     </a>
@@ -80,31 +86,69 @@ title: "Andi & Anna Games Room"
   </div>
 </section>
 
-<section id="games" class="space-y-4">
+<section class="mt-14 grid gap-8 lg:grid-cols-2">
+  <div class="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-indigo-900/30">
+    <p class="text-sm font-semibold text-blue-200">Flagship</p>
+    <h3 class="text-2xl font-bold text-white">Salesforce Sheet</h3>
+    <p class="mt-2 text-white/70">A Salesforce-inspired spreadsheet console with inline editing, stage filtering, clipboard export, and CSV downloads.</p>
+    <ul class="mt-4 space-y-2 text-sm text-white/80">
+      <li class="flex items-center gap-2"><span class="text-emerald-300">●</span>Dropdown-driven stages and calendar dates.</li>
+      <li class="flex items-center gap-2"><span class="text-emerald-300">●</span>Inline math for amounts with friendly currency formatting.</li>
+      <li class="flex items-center gap-2"><span class="text-emerald-300">●</span>Instant export to CSV or clipboard for sharing.</li>
+    </ul>
+    <div class="mt-5 flex flex-wrap gap-3">
+      <a href="{{ '/feature/salesforce-sheet/' | relative_url }}" class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-emerald-400 via-blue-500 to-indigo-500 px-4 py-2 text-sm font-semibold text-slate-900 shadow-md shadow-blue-500/30">Open sheet</a>
+      <a href="{{ '/feature/salesforce-sheet/' | relative_url }}#about" class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/5 px-4 py-2 text-sm font-semibold text-white">See how it works</a>
+    </div>
+  </div>
+  <div class="rounded-3xl border border-white/10 bg-gradient-to-br from-slate-900/80 via-indigo-900/50 to-slate-800 p-6 shadow-xl shadow-indigo-900/50">
+    <p class="text-sm font-semibold text-purple-200">Why it feels better</p>
+    <div class="mt-3 grid gap-4 sm:grid-cols-2">
+      <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+        <p class="text-white font-semibold">Glass panels</p>
+        <p class="text-sm text-white/70">Cards float with soft borders and blur to highlight the data you care about.</p>
+      </div>
+      <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+        <p class="text-white font-semibold">Responsive from day one</p>
+        <p class="text-sm text-white/70">Grids, buttons, and typography scale gracefully on desktops and tablets.</p>
+      </div>
+      <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+        <p class="text-white font-semibold">Inclusive motion</p>
+        <p class="text-sm text-white/70">Subtle hover lifts and glow effects add warmth without overpowering the UI.</p>
+      </div>
+      <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+        <p class="text-white font-semibold">Ready to remix</p>
+        <p class="text-sm text-white/70">Drop new folders under <code class="text-xs bg-white/10 px-1.5 py-0.5 rounded">/games</code> or <code class="text-xs bg-white/10 px-1.5 py-0.5 rounded">/feature</code> and link them instantly.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="games" class="mt-14 space-y-4">
   <div class="flex items-center justify-between gap-4">
     <div>
-      <p class="text-sm font-semibold text-blue-600">Game shelf</p>
-      <h2 class="text-2xl font-bold text-slate-900">Choose your adventure</h2>
+      <p class="text-sm font-semibold text-blue-200">Playground shelf</p>
+      <h2 class="text-2xl font-bold text-white">Bring the joy back</h2>
     </div>
-    <span class="inline-flex items-center gap-2 rounded-full bg-emerald-100 text-emerald-700 px-3 py-1 text-sm font-semibold ring-1 ring-emerald-200">Updated with Flowbite</span>
+    <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-sm font-semibold text-white ring-1 ring-white/15">{{ site.data.games | size }} creative demos</span>
   </div>
   <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
     {% for game in site.data.games %}
     <a
       href="{{ '/games/' | append: game.id | append: '/index.html' | relative_url }}"
-      class="group block h-full overflow-hidden rounded-2xl bg-white shadow-md ring-1 ring-slate-200 transition hover:-translate-y-1 hover:shadow-xl"
+      class="group block h-full overflow-hidden rounded-2xl border border-white/10 bg-white/5 shadow-lg shadow-indigo-900/30 ring-1 ring-transparent transition hover:-translate-y-1 hover:ring-blue-300/40"
     >
       <div class="bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 px-5 py-4 text-white">
-        <p class="text-xs font-semibold uppercase tracking-wide text-blue-200">{{ game.category | default: 'Game' }}</p>
+        <p class="text-xs font-semibold uppercase tracking-wide text-blue-200">{{ game.category | default: 'Play' }}</p>
         <h3 class="text-lg font-bold">{{ game.title }}</h3>
       </div>
       <div class="p-5 space-y-3">
         {% if game.description %}
-        <p class="text-sm text-slate-600">{{ game.description | escape }}</p>
+        <p class="text-sm text-white/80">{{ game.description | escape }}</p>
         {% else %}
-        <p class="text-sm text-slate-600">Launch and play instantly.</p>
+        <p class="text-sm text-white/80">Launch and play instantly.</p>
         {% endif %}
-        <div class="flex items-center justify-between text-sm font-semibold text-blue-600">
+        <div class="flex items-center justify-between text-sm font-semibold text-blue-200">
           <span class="inline-flex items-center gap-2">Play now</span>
           <svg class="h-4 w-4 transition-transform group-hover:translate-x-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10" aria-hidden="true">
             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 5h12m0 0L9 1m4 4L9 9" />
@@ -113,15 +157,5 @@ title: "Andi & Anna Games Room"
       </div>
     </a>
     {% endfor %}
-  </div>
-</section>
-
-<section class="mt-12 rounded-2xl bg-white/70 p-6 shadow-sm ring-1 ring-slate-200">
-  <div class="flex flex-wrap items-center justify-between gap-4">
-    <div>
-      <p class="text-sm font-semibold text-blue-600">Add your own</p>
-      <p class="text-slate-700">Create a folder under <code class="text-xs bg-slate-900/90 text-white px-2 py-1 rounded">/games/</code> and register it in <code class="text-xs bg-slate-900/90 text-white px-2 py-1 rounded">_data/games.yml</code>.</p>
-    </div>
-    <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">Flowbite cards &amp; gradients everywhere</span>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- restyle the site into a Beautiful Apps hub with a new hero, app grid, and flagship highlight
- refresh navigation and footer to match the glassy gradient design system
- harden the Salesforce Sheet by waiting for jspreadsheet to load, adding safe IDs, and offering a graceful error state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693813151468832e85530172897a77fa)