### PR TITLE
Fix CDN integrity and three.js module imports

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
   <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.5.2/flowbite.min.css"
-    integrity="sha512-6uH6fXdv6QdZgNAtTJ1K1BqOU0V7v0r0QABeyWqh3yx4X9bCPCzqzmXWeX3Pv5r1usRfsyai0hZbItCeFvcfQQ=="
+    integrity="sha512-Lnb4rmvlf0eGfqcEGPKkjoZPXBQFsZu3yl47cwfJxCQp7MlfqIKrS+2eYEimTX8PWh4h5P8JAQbzX78q4gIRDQ=="
     crossorigin="anonymous"
     referrerpolicy="no-referrer"
   />
@@ -80,7 +80,7 @@
     </div>
   </footer>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.5.2/flowbite.min.js" integrity="sha512-lvkSB9bnpNFHmf070mgwhqJPRuHNEweSFNuo1RMvR+I/oacgDsYnxQyqEmLBoD1aiZ6YdPz7Il9CDb6c5FqZfw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.5.2/flowbite.min.js" integrity="sha512-Fx0qfamN0X4phfkgQkEWlTY63R375YIvgGFI1idvxR81h3MeaC63EsVWMbSwDnu0uk87YnvTH11ZVwHxSj+dwA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script>
     (function () {
       const toggle = document.getElementById('mobile-menu-toggle');

--- a/games/stick-intersections/index.html
+++ b/games/stick-intersections/index.html
@@ -103,18 +103,9 @@
     <div id="scene-container"></div>
   </div>
 
-  <script type="importmap">
-    {
-      "imports": {
-        "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js",
-        "three/examples/jsm/controls/OrbitControls": "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js"
-      }
-    }
-  </script>
-
   <script type="module">
-    import * as THREE from 'three';
-    import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
+    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+    import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js';
 
     const container = document.getElementById('scene-container');
     const scene = new THREE.Scene();

--- a/games/three-triangle/index.html
+++ b/games/three-triangle/index.html
@@ -109,18 +109,9 @@
     <div id="scene-container"></div>
   </div>
 
-  <script type="importmap">
-    {
-      "imports": {
-        "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js",
-        "three/examples/jsm/controls/OrbitControls": "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js"
-      }
-    }
-  </script>
-
   <script type="module">
-    import * as THREE from 'three';
-    import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
+    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+    import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js';
 
     const container = document.getElementById('scene-container');
     const scene = new THREE.Scene();

--- a/games/tokyo-city-3d/index.html
+++ b/games/tokyo-city-3d/index.html
@@ -167,18 +167,9 @@
     <div id="scene-container"></div>
   </div>
 
-  <script type="importmap">
-    {
-      "imports": {
-        "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js",
-        "three/examples/jsm/controls/OrbitControls.js": "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js"
-      }
-    }
-  </script>
-
   <script type="module">
-    import * as THREE from 'three';
-    import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+    import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js';
 
     const container = document.getElementById('scene-container');
     const hud = document.querySelector('.hud');

--- a/games/train-3d/index.html
+++ b/games/train-3d/index.html
@@ -101,18 +101,9 @@
     <div id="scene-container"></div>
   </div>
 
-  <script type="importmap">
-    {
-      "imports": {
-        "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js",
-        "three/examples/jsm/controls/OrbitControls.js": "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js"
-      }
-    }
-  </script>
-
   <script type="module">
-    import * as THREE from 'three';
-    import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+    import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js';
 
     const container = document.getElementById('scene-container');
     const scene = new THREE.Scene();


### PR DESCRIPTION
## Summary
- update Flowbite CDN links to use correct integrity hashes
- switch three.js demo pages to direct CDN module imports instead of bare specifiers

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bbfca5514832ebbd7ee0768b3f1e2)