### PR TITLE
Fix Three.js module resolution on photo-to-3d feature page

### DIFF
--- a/feature/photo-to-3d/index.html
+++ b/feature/photo-to-3d/index.html
@@ -117,9 +117,18 @@ description: "Upload a picture and turn it into a 3D relief using a live height 
   </div>
 </section>
 
+<script type="importmap">
+  {
+    "imports": {
+      "three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+      "three/examples/jsm/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/"
+    }
+  }
+</script>
+
 <script type="module">
-  import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js';
-  import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/controls/OrbitControls.js';
+  import * as THREE from 'three';
+  import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
   const sceneShell = document.getElementById('scene-shell');
   const rendererHost = document.getElementById('renderer');


### PR DESCRIPTION
## Summary
- add an import map so Three.js and its examples resolve when loaded from the CDN
- switch module imports to use the mapped specifiers for consistent loading

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bc2221b24832ebdd555deddf3fa31)