### PR TITLE
Add import maps for three.js demos

### DIFF
--- a/feature/photo-to-3d/index.html
+++ b/feature/photo-to-3d/index.html
@@ -117,6 +117,14 @@ description: "Upload a picture and turn it into a 3D relief using a live height 
   </div>
 </section>
 
+<script type="importmap">
+  {
+    "imports": {
+      "three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js"
+    }
+  }
+</script>
+
 <script type="module">
   import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js';
   import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/controls/OrbitControls.js';

--- a/games/cube-perfect/index.html
+++ b/games/cube-perfect/index.html
@@ -195,6 +195,14 @@
     <canvas id="three-canvas"></canvas>
   </div>
 
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://unpkg.com/three@0.158.0/build/three.module.js"
+      }
+    }
+  </script>
+
   <script type="module">
     import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
     import { OrbitControls } from 'https://unpkg.com/three@0.158.0/examples/jsm/controls/OrbitControls.js';

--- a/games/stick-intersections/index.html
+++ b/games/stick-intersections/index.html
@@ -103,6 +103,14 @@
     <div id="scene-container"></div>
   </div>
 
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js"
+      }
+    }
+  </script>
+
   <script type="module">
     import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
     import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js';

--- a/games/three-triangle/index.html
+++ b/games/three-triangle/index.html
@@ -109,6 +109,14 @@
     <div id="scene-container"></div>
   </div>
 
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js"
+      }
+    }
+  </script>
+
   <script type="module">
     import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
     import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js';

--- a/games/tokyo-city-3d/index.html
+++ b/games/tokyo-city-3d/index.html
@@ -167,6 +167,14 @@
     <div id="scene-container"></div>
   </div>
 
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js"
+      }
+    }
+  </script>
+
   <script type="module">
     import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
     import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js';

--- a/games/train-3d/index.html
+++ b/games/train-3d/index.html
@@ -101,6 +101,14 @@
     <div id="scene-container"></div>
   </div>
 
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js"
+      }
+    }
+  </script>
+
   <script type="module">
     import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
     import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js';


### PR DESCRIPTION
## Summary
- add explicit import maps to three.js demo pages to resolve the `three` module specifier when loading OrbitControls
- align each import map to the CDN version already used by the page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c113599ec832e85f6c8e63e167fb2)